### PR TITLE
feat(ui): add responsive scoreboard and footer for mobile view

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -24,11 +24,16 @@ body {
   .game-container {
     height: 30vh;
     width: 100%; /* istersen genişliği de tam ekran yapabilirsin */
+    margin-bottom: 60px; /* Footer için alan bırak */
+    margin-top: 80px; /* Scoreboard için alan bırak */
   }
   body {
     min-height: 100vh;
+    align-items: flex-start; /* Elemanları üstten başlat */
+    padding-top: 0;
+    padding-bottom: 60px; /* Footer için alan bırak */
   }
-  .controls{
+  .controls {
     flex-direction: column;
   }
 }
@@ -174,20 +179,91 @@ button:focus {
   box-shadow: none;
 }
 
+#scoreboard {
+  display: none;
+}
 
-.footer { 
-  position: fixed;
-  bottom: 0;
-  left: 0;
-  width: 100%;
-  text-align: center;
-  background: rgba(26, 26, 26, 0.9);
-  padding: 10px 0;
-  z-index: 1000;
+@media screen and (max-width: 768px) {
+  #scoreboard {
+    display: flex;
+    position: fixed;
+    top: 10px;
+    left: 0;
+    right: 0;
+    width: 100%;
+    padding: 10px;
+    gap: 10px;
+    justify-content: center;
+    margin-top: 0;
+    font-family: "Michroma", sans-serif;
+    font-weight: bold;
+    z-index: 200;
+    background-color: rgba(26, 26, 26, 0.95);
+    border-bottom: 1px solid #333;
+    box-sizing: border-box;
+  }
+}
+
+@media screen and (max-width: 768px) {
+  .user, .pc {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    min-width: 0;
+    justify-content: center;
+    align-items: center;
+    text-align: center;
+    border: 1px solid #d14646;
+    border-radius: 8px;
+    padding: 5px 5px;
+    margin: 0;
+    background-color: rgba(209, 70, 70, 0.1);
+    font-family: "Michroma", sans-serif;
+    font-weight: bold;
+  }
+
+  .user p, .pc p, .user div, .pc div {
+    margin: 5px 0;
+    font-size: 14px;
+    font-family: "Michroma", sans-serif;
+    font-weight: bold;
+    color: #fff;
+  }
+
+  .user p:last-child, .pc div:last-child {
+    font-size: 18px;
+    color: #d14646;
+    font-weight: bold;
+  }
+}
+
+
+.footer {
+  display: none;
+}
+
+@media screen and (max-width: 768px) {
+  .footer {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    background-color: rgba(26, 26, 26, 0.95);
+    padding: 10px 0;
+    font-family: "Michroma", sans-serif;
+    font-weight: bold;
+    z-index: 1000;
+    border-top: 1px solid #333;
+  }
 }
 
 .footer p {
   margin: 0;
   font-size: 14px;
   color: #ccc;
+  font-family: "Michroma", sans-serif;
+  font-weight: bold;
 }

--- a/index.html
+++ b/index.html
@@ -10,8 +10,13 @@
     />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+
     <link
       href="https://fonts.googleapis.com/css2?family=Bangers&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Michroma&display=swap"
       rel="stylesheet"
     />
     <!-- <style>
@@ -191,6 +196,16 @@
     <link rel="stylesheet" href="css/style.css" />
   </head>
   <body>
+    <div id="scoreboard">
+      <div class="user">
+        <p>User</p>
+        <p id="userScore">0</p>
+      </div>
+      <div class="pc">
+        <p>Computer</p>
+        <div id="computerScore">0</div>
+      </div>
+    </div>
     <div class="game-container">
       <canvas id="gameCanvas"></canvas>
       <div class="controls">
@@ -260,7 +275,9 @@
           <button id="closeSettingsBtn">Kapat</button>
         </div>
       </div>
-
+      <footer class="footer">
+        <p>PONG GAME</p>
+      </footer>
     </div>
 
     <audio id="hitSound" src="sounds/scoreSound.mp3" preload="auto"></audio>
@@ -284,10 +301,6 @@
       src="sounds/tus-sesi.mp3"
       preload="auto"
     ></audio>
-
-    <footer class="footer">
-      <p>PONG GAME</p>
-    </footer>
 
     <!-- <script>
       document.querySelectorAll("button").forEach((btn) => {

--- a/js/functions.js
+++ b/js/functions.js
@@ -279,11 +279,23 @@
         settingsBtn.innerHTML = '<i class="fas fa-cog"></i> Ayarlar';
       }
 
+      // Scoreboard update function
+      function updateScoreboard() {
+        const userScoreElement = document.getElementById("userScore");
+        const computerScoreElement = document.getElementById("computerScore");
+        
+        if (userScoreElement && computerScoreElement) {
+          userScoreElement.textContent = game.player.score;
+          computerScoreElement.textContent = game.computer.score;
+        }
+      }
+
       // Event listener
       restartBtn.addEventListener("click", () => {
         document.getElementById("levelMenu").style.display = "flex";
         game.player.score = 0;
         game.computer.score = 0;
+        updateScoreboard(); // Update scoreboard when game restarts
         initializeGameElements();
         gameOver = false;
         isPaused = true;
@@ -346,6 +358,7 @@
         document.getElementById("levelMenu").style.display = "none";
         game.player.score = 0;
         game.computer.score = 0;
+        updateScoreboard(); // Update scoreboard when game starts
         initializeGameElements();
         gameOver = false;
         isPaused = false;
@@ -373,13 +386,19 @@
       }
 
       function drawScore() {
-        ctx.font = `${canvas.height * 0.06}px Arial`;
-        ctx.fillText(game.player.score, canvas.width / 4, canvas.height * 0.1);
-        ctx.fillText(
-          game.computer.score,
-          (3 * canvas.width) / 4,
-          canvas.height * 0.1
-        );
+        // Only draw scores on canvas for desktop (when scoreboard is hidden)
+        if (window.innerWidth > 768) {
+          ctx.font = `${canvas.height * 0.06}px Arial`;
+          ctx.fillStyle = "#fff";
+          ctx.textAlign = "center";
+          ctx.fillText(game.player.score, canvas.width / 4, canvas.height * 0.1);
+          ctx.fillText(
+            game.computer.score,
+            (3 * canvas.width) / 4,
+            canvas.height * 0.1
+          );
+        }
+        // On mobile, scores are handled by external scoreboard
       }
 
       function drawFirework(x, y) {
@@ -661,6 +680,7 @@
           if (ball.x < 0) {
             game.computer.score++;
             playSound(scoreSound);
+            updateScoreboard(); // Update scoreboard when computer scores
             if (balls.length > 1) {
               balls.splice(index, 1);
             } else {
@@ -670,6 +690,7 @@
           if (ball.x > canvas.width) {
             game.player.score++;
             playSound(scoreSound);
+            updateScoreboard(); // Update scoreboard when player scores
             if (balls.length > 1) {
               balls.splice(index, 1);
             } else {


### PR DESCRIPTION
- Introduced a new scoreboard element visible only on screens smaller than 768px
- Styled scoreboard with flex layout, distinct user and computer sections, and mobile-friendly typography
- Hid the desktop footer on mobile and created a fixed footer for small screens
- Updated canvas score drawing logic to hide scores on mobile when scoreboard is shown
- Added updateScoreboard function to sync